### PR TITLE
allow redefining $POSTGRES_USER env variable

### DIFF
--- a/create_extension.sh
+++ b/create_extension.sh
@@ -5,7 +5,7 @@
 # the extensions having different eid's.
 gosu postgres psql --dbname template1 <<EOSQL
     CREATE EXTENSION hstore;
-    DROP DATABASE postgres;
-    CREATE DATABASE postgres TEMPLATE template1;
+    DROP DATABASE $POSTGRES_USER;
+    CREATE DATABASE $POSTGRES_USER TEMPLATE template1;
 EOSQL
 


### PR DESCRIPTION
If someone defines the $POSTGRES_USER env variable, the database created will also be $POSTGRES_USER. See https://hub.docker.com/_/postgres/.
